### PR TITLE
Fix thrown beam energy for python generator example

### DIFF
--- a/Generators/python/examples/phasespace3body.py
+++ b/Generators/python/examples/phasespace3body.py
@@ -16,11 +16,14 @@ def WriteHDDM(hddm_output, particlesP4, particlesGeantID, particlesPDGID):
     rea = pev[0].addReactions(1)
     bea = rea[0].addBeams(1)
     bea[0].type = 1
+    prop = bea[0].addPropertiesList()
+    prop[0].charge = 0
+    prop[0].mass = 0.0
     mom = bea[0].addMomenta(1)
     mom[0].E = E
     mom[0].px = 0
     mom[0].py = 0
-    mom[0].pz = 0
+    mom[0].pz = E
 
     tar = rea[0].addTargets(1)
     tar[0].type = 14

--- a/Generators/python/examples/phasespace3body.py
+++ b/Generators/python/examples/phasespace3body.py
@@ -211,9 +211,6 @@ gRandom.SetSeed(seed)
 # get run-specific flux from CCDB
 hflux = GetFluxCCDB(run, Emin, Emax)
 
-cflux = TCanvas( "cflux", "cflux", 800, 600 )
-hflux.Draw()
-
 # proton target
 target = TLorentzVector(0.0, 0.0, 0.0, 0.93827)
 

--- a/Generators/python/examples/phasespace3body.py
+++ b/Generators/python/examples/phasespace3body.py
@@ -1,4 +1,4 @@
-# -t 5
+# 
 import os,sys
 from ROOT import TFile,TH1F,TH1D,TH2D,TF1,TLorentzVector,TGenPhaseSpace,TCanvas,gRandom
 from array import array
@@ -141,7 +141,7 @@ Emin = 8.2
 Emax = 8.8
 tmin = 0.0
 tmax = 1.5
-tslope = 1.099
+tslope = 0.0
 Mmin = 0.0
 Mmax = 1.7
 


### PR DESCRIPTION
Bug in generated beam photon energy.  Only affected DMCReaction beam energy definition which is used for thrown trees, but reconstructed beam energies should have been fine.