### PR TITLE
Update MakeMC.csh for the python version running psflux

### DIFF
--- a/MakeMC.csh
+++ b/MakeMC.csh
@@ -1020,7 +1020,7 @@ if ( "$GENR" != "0" ) then
 		set generator_return_code=$status
 	else if ( "$GENERATOR" == "mc_gen" ) then
 		echo "RUNNING MC_GEN"
-		python $HD_UTILITIES_HOME/psflux/plot_flux_ccdb.py -b $RUN_NUMBER -e $RUN_NUMBER
+		python3.6 $HD_UTILITIES_HOME/psflux/plot_flux_ccdb.py -b $RUN_NUMBER -e $RUN_NUMBER
 		set MCGEN_FLUX_DIR=`printf './flux_%d_%d.ascii' "$RUN_NUMBER" "$RUN_NUMBER"`
 		set ROOTSCRIPT=`printf '$MCWRAPPER_CENTRAL/Generators/mc_gen/Flux_to_Ascii.C("flux_%s_%s.root")' "$RUN_NUMBER" "$RUN_NUMBER" `
 		root -l -b -q $ROOTSCRIPT


### PR DESCRIPTION
This is to fix a bug only effecting mc_gen who uses psflux tool for the flux information. According to note in https://github.com/JeffersonLab/hd_utilities/tree/master/psflux#python-version-notes, the python version being used should match the one used to compile root. This is only a temporary fix. Ideally should have it read off from the returned string of the command "root-config --python-version" directly but need more testing.