### PR TITLE
mcmsear jana syntax update

### DIFF
--- a/MakeMC.csh
+++ b/MakeMC.csh
@@ -1697,7 +1697,6 @@ else
 		echo "RUNNING MCSMEAR"
 		
 		# Detect which version of jana is being used:
-		echo "using config file: "$jana_config_file
 		$runSmear jana -version
 		set jana_return_code=$status
 		if ( $jana_return_code != 0 ) then

--- a/MakeMC.sh
+++ b/MakeMC.sh
@@ -1750,7 +1750,6 @@ else
 		echo "RUNNING MCSMEAR"
 		
 		# Detect which version of jana is being used:
-		echo "using config file: "$jana_config_file
 		$runSmear jana -version
 		jana_return_code=$?
 		if [[ $jana_return_code != 0 ]]; then


### PR DESCRIPTION
Corrections were made to the thread timeout syntax for jana within the mcsmear step.

I copied the same procedure used during the reconstruction step to determine which version of JANA is being used, and then defined a new variable ("JANA_TIMEOUT_THREAD") to store the appropriate syntax for each version.