### PR TITLE
Update random trigger files location on osdf.

### DIFF
--- a/Utilities/MCMerger.py
+++ b/Utilities/MCMerger.py
@@ -210,7 +210,7 @@ def bash_configurations(name_map, path, mc_dir):
 
 def get_entry(file_name):
     """Return the prefix, run number, and suffix of file_name as a tuple by matching on the run number."""
-    match = re.search("([0-9]{6})_[0-9]{3}", file_name)
+    match = re.search("([0-9]{6})_([0-9]{3,4})(?![0-9])", file_name)
     if match:
         prefix = file_name[:match.start()]
         run_num = match.group(1)

--- a/gluex_MC.py
+++ b/gluex_MC.py
@@ -2036,8 +2036,19 @@ def GetRandTrigNums(BGFOLD,RANDBGTAG,BATCHSYS,RUNNUM):
                         running_hostname=socket.gethostname()
                         if running_hostname == "scosg16.jlab.org" or running_hostname == "scosg20.jlab.org" or running_hostname == "scosg2201.jlab.org":
                                 os.system("mkdir -p /tmp/"+RANDBGTAG)
-                                print("scp dtn2303:/work/osgpool/halld/random_triggers/"+RANDBGTAG+"/run"+formattedRUNNUM+"_random.hddm /tmp/"+RANDBGTAG)
-                                os.system("scp dtn2303:/work/osgpool/halld/random_triggers/"+RANDBGTAG+"/run"+formattedRUNNUM+"_random.hddm /tmp/"+RANDBGTAG)
+
+                                # Try copying the file with pelican:
+                                pelican_get_string="pelican object get osdf://jlab-osdf/gluex/osgpool/random_triggers/"+RANDBGTAG+"/run"+formattedRUNNUM+"_random.hddm /tmp/"+RANDBGTAG
+                                token_str='eval `ssh-agent`; /usr/bin/ssh-add; '
+                                agent_kill_str="; ssh-agent -k"
+                                print(token_str+pelican_get_string+agent_kill_str)
+                                
+                                os.environ["BEARER_TOKEN_FILE"]="/var/run/user/10967/bt_u10967"
+                                os.environ["XDG_RUNTIME_DIR"]="/run/user/10967"
+                                my_env=os.environ.copy()
+
+                                p = subprocess.Popen(token_str+pelican_get_string+agent_kill_str, env=my_env ,stdin=subprocess.PIPE,stdout=subprocess.PIPE, stderr=subprocess.PIPE,bufsize=-1,shell=True,close_fds=True)
+                                output, errors = p.communicate()
 
                         if not os.path.isfile(realpath):
                                 print("can't find file to scan.")


### PR DESCRIPTION
Updated the location pelican retrieves random trigger files from the osdf endpoint. 

I also added a check to the MakeMC.sh script to count the number of random trigger events in a file for cases where the gluex_MC.py wasn't able to provide an accurate count. This problem came up last week when a user submitted a set of simulations using random trigger background files that didn't yet have entries into the "Randoms" database table. Consequently, gluex_MC.py tried to copy them from dtn2303 (which didn't work), and then it ran MakeMC.sh with "RANDOM_TRIG_NUM_EVT" set to -1.  I replaced the "scp" call from dtn2303 in gluex_MC.py with a "pelican object get" instead, to rectify this, so the added count.py inside of MakeMC.sh might be unnecessary at this point. If for some reason pelican failed to retrieve the file in gluex_MC.py, it would probably also fail inside of MakeMC.sh too. But there could be some edge cases where that might not be true. 

The last change I made was a small edit to the "get_entry" function inside of MCMerger.py. The previous version created issues when a file name had this pattern: "123456_1234_decay_evtgen_smeared.hddm" (i.e. when the normally 3-digit extension was 4-digits instead). This issue arises whenever users submit high-statistics simulation projects based on a single run number.