### PR TITLE
Added an optional flag functionality for genr8 

### DIFF
--- a/MakeMC.csh
+++ b/MakeMC.csh
@@ -1126,12 +1126,14 @@ if ( "$GENR" != "0" ) then #run generation
 	if ( "$GENERATOR" == "genr8" ) then
 		echo "RUNNING GENR8"
 		set RUNNUM=$formatted_runNumber+$formatted_fileNumber
+		set optionals_line=`head -n 1 $STANDARD_NAME.conf | grep '^% -' | sed -r 's/.//'`
 		#sed -i 's/TEMPCOHERENT/'$COHERENT_PEAK'/' $STANDARD_NAME.conf
 		#sed -i 's/TEMPMAXE/'$GEN_MAX_ENERGY'/' $STANDARD_NAME.conf
 		sed -i 's/TEMPBEAMCONFIG/'$STANDARD_NAME'_beam.conf/' $STANDARD_NAME.conf
 		# RUN genr8 and convert
-		echo $runGen genr8 -r$formatted_runNumber -M$EVT_TO_GEN -A$STANDARD_NAME.ascii < $STANDARD_NAME.conf
-		$runGen genr8 -r$formatted_runNumber -M$EVT_TO_GEN -A$STANDARD_NAME.ascii < $STANDARD_NAME.conf
+		echo $optionals_line
+		echo $runGen genr8 -r$formatted_runNumber -M$EVT_TO_GEN $optionals_line -A$STANDARD_NAME.ascii < $STANDARD_NAME.conf
+		$runGen genr8 -r$formatted_runNumber -M$EVT_TO_GEN $optionals_line -A$STANDARD_NAME.ascii < $STANDARD_NAME.conf
 		set generator_return_code=$status
 		$runGen genr8_2_hddm -V"0 0 0 0" $STANDARD_NAME.ascii
 	else if ( "$GENERATOR" == "genr8_new" ) then

--- a/MakeMC.sh
+++ b/MakeMC.sh
@@ -1188,12 +1188,14 @@ if [[ "$GENR" != "0" ]]; then # run generation
 	if [[ "$GENERATOR" == "genr8" ]]; then
 		echo "RUNNING GENR8"
 		RUNNUM=$formatted_runNumber+$formatted_fileNumber
+		optionals_line=`head -n 1 $STANDARD_NAME.conf | grep '^% -' | sed -r 's/.//'`
 		#sed -i 's/TEMPCOHERENT/'$COHERENT_PEAK'/' $STANDARD_NAME.conf
 		#sed -i 's/TEMPMAXE/'$GEN_MAX_ENERGY'/' $STANDARD_NAME.conf
 		sed -i 's/TEMPBEAMCONFIG/'$STANDARD_NAME'_beam.conf/' $STANDARD_NAME.conf
 		# RUN genr8 and convert
-		echo $runGen genr8 -r$formatted_runNumber -M$EVT_TO_GEN -A$STANDARD_NAME.ascii < $STANDARD_NAME.conf #$config_file_name
-		$runGen genr8 -r$formatted_runNumber -M$EVT_TO_GEN -A$STANDARD_NAME.ascii < $STANDARD_NAME.conf #$config_file_name
+		echo $optionals_line
+		echo $runGen genr8 -r$formatted_runNumber -M$EVT_TO_GEN $optionals_line -A$STANDARD_NAME.ascii < $STANDARD_NAME.conf #$config_file_name
+		$runGen genr8 -r$formatted_runNumber -M$EVT_TO_GEN $optionals_line -A$STANDARD_NAME.ascii < $STANDARD_NAME.conf #$config_file_name
 		generator_return_code=$?
 		$runGen genr8_2_hddm -V"0 0 0 0" $STANDARD_NAME.ascii
 	elif [[ "$GENERATOR" == "genr8_new" ]]; then


### PR DESCRIPTION
The functionality reads the first line of the genr8 config file, and if the line starts with `% -` it will be recognized as optional flags. This functionality should make it backward compatible since many files in the past might have started with a string of `%`

This functionality was implemented to allow the user to specify a mass window for the meson system. Here are a few usage examples for this functionality:
`% -Mmin2` : this will pass an optional flag that generates events with a minimum meson mass of 2 GeV
`% -Mmax3`:  this will pass an optional flag that generates events with a maximum meson mass of 3 GeV
`% -Mmin2 -Mmax3`: this will pass an optional flag that generates events in the window 2 GeV <= M(meson) <= 3 GeV

