### PR TITLE
Corrected Flag

### DIFF
--- a/MakeMC.csh
+++ b/MakeMC.csh
@@ -1768,7 +1768,7 @@ else
 		echo "RUNNING MCSMEAR"
 		
 		# Detect which version of jana is being used:
-		$runSmear jana -version
+		$runSmear jana --version
 		set jana_return_code=$status
 		if ( $jana_return_code != 0 ) then
 			set JANA_MAJOR_VERSION=2

--- a/MakeMC.sh
+++ b/MakeMC.sh
@@ -1826,7 +1826,7 @@ else
 		echo "RUNNING MCSMEAR"
 		
 		# Detect which version of jana is being used:
-		$runSmear jana -version
+		$runSmear jana --version
 		jana_return_code=$?
 		if [[ $jana_return_code != 0 ]]; then
 			export JANA_MAJOR_VERSION=2


### PR DESCRIPTION
As I was looking at MCWrapper output, I saw these lines being printed:
```
RUNNING MCSMEAR
Invalid command line flag '-version'

Usage:
    jana [options] source1 source2 ...

Description:
    Command-line interface for running JANA plugins. This can be used to
    read in events and process them. Command-line flags control configuration
    while additional arguments denote input files, which are to be loaded and
    processed by the appropriate EventSource plugin.

Options:
   -h   --help                  Display this message
   -Pkey=value                        Specify a configuration parameter

   -v   --version                     Display version information
   -c   --configs                     Display configuration parameters
   -l   --loadconfigs <file>          Load configuration parameters from file
   -d   --dumpconfigs <file>          Dump configuration parameters to file
   -b   --benchmark                   Run in benchmark mode
        --inspect-collection <name>   Inspect a collection
        --inspect-component <name>    Inspect a component
Example:
    jana -Pplugins=plugin1,plugin2,plugin3 -Pnthreads=8 inputfile1.txt

Using JANA_MAJOR_VERSION: 2
```
They originate from this line in the [MakeMC.(c)sh](https://github.com/JeffersonLab/gluex_MCwrapper/blob/1f21eb474418f98d46e05f76d9a6261db14cba01/MakeMC.csh#L1771)

The output tells us the solution is to use `--version` . This changes reflect that