### PR TITLE
Csh bug fix

### DIFF
--- a/MakeMC.csh
+++ b/MakeMC.csh
@@ -207,7 +207,7 @@ if ( "$BATCHSYS" == "OSG" && "$BATCHRUN" == "1" ) then
 endif
 
 
-setenv XRD_RANDOMS_URL osdf://jlab-osdf/gluex/osgpool/random_triggers/
+setenv XRD_RANDOMS_URL root://dtn2304.jlab.org:8443/jlab-osdf-ro/halld/osgpool/
 setenv RANDOMS_PREPEND ""
 setenv LD_PRELOAD ""
 if ( "$MCWRAPPER_RUN_LOCATION" == "JLAB" || `hostname` =~ '*.jlab.org' ) then
@@ -222,7 +222,7 @@ if ( -f /usr/lib64/libXrdPosixPreload.so && "$BKGFOLDSTR" != "None" && "$GENR" !
 
 	if ( "$BKGFOLDSTR" == "Random" ) then
 		
-		set con_test=`/usr/bin/pelican object ls ${$XRD_RANDOMS_URL}/$RANDBGTAG/run$formatted_runNumber\_random.hddm | head -c 1`
+		set con_test=`ls $XRD_RANDOMS_URL/random_triggers/$RANDBGTAG/run$formatted_runNumber\_random.hddm | head -c 1`
 
 		if ( $con_test != "r" ) then
 			echo "JLAB Connection test failed. Falling back to UConn ...."

--- a/MakeMC.csh
+++ b/MakeMC.csh
@@ -207,8 +207,8 @@ if ( "$BATCHSYS" == "OSG" && "$BATCHRUN" == "1" ) then
 endif
 
 
-setenv XRD_RANDOMS_URL root://dtn2304.jlab.org:8443/jlab-osdf-ro/halld/osgpool/
-setenv RANDOMS_PREPEND ""
+setenv XRD_RANDOMS_URL root://dtn2304.jlab.org:8443
+setenv RANDOMS_PREPEND /jlab-osdf-ro/halld/osgpool/
 setenv LD_PRELOAD ""
 if ( "$MCWRAPPER_RUN_LOCATION" == "JLAB" || `hostname` =~ '*.jlab.org' ) then
 	setenv RUNNING_DIR "./"
@@ -222,9 +222,19 @@ if ( -f /usr/lib64/libXrdPosixPreload.so && "$BKGFOLDSTR" != "None" && "$GENR" !
 
 	if ( "$BKGFOLDSTR" == "Random" ) then
 		
-		set con_test=`ls $XRD_RANDOMS_URL/random_triggers/$RANDBGTAG/run$formatted_runNumber\_random.hddm | head -c 1`
+		#set con_test=`ls $XRD_RANDOMS_URL/random_triggers/$RANDBGTAG/run$formatted_runNumber\_random.hddm | head -c 1`
+		echo `ls $XRD_RANDOMS_URL/$RANDOMS_PREPEND/random_triggers/$RANDBGTAG/run$formatted_runNumber\_random.hddm`
+		setenv con_test `ls $XRD_RANDOMS_URL/$RANDOMS_PREPEND/random_triggers/$RANDBGTAG/run$formatted_runNumber\_random.hddm | head -c 1`
 
-		if ( $con_test != "r" ) then
+		setenv contest `xrdfs $XRD_RANDOMS_URL ls $RANDOMS_PREPEND/random_triggers/$RANDBGTAG/run$formatted_runNumber\_random.hddm | wc -l`
+		#echo "Executing command: xrdfs $XRD_RANDOMS_URL ls /gluex/mcwrap/random_triggers/$RANDBGTAG/run${formatted_runNumber}_random.hddm | wc -l"
+		#xrdfs $XRD_RANDOMS_URL ls /gluex/mcwrap/random_triggers/$RANDBGTAG/run${formatted_runNumber}_random.hddm | wc -l
+		#export con_test=$(xrdfs $XRD_RANDOMS_URL ls /gluex/mcwrap/random_triggers/$RANDBGTAG/run${formatted_runNumber}_random.hddm)
+		echo "random trigger connection test: $con_test"
+		echo xrdfs $XRD_RANDOMS_URL ls $RANDOMS_PREPEND/random_triggers/$RANDBGTAG/run$formatted_runNumber\_random.hddm
+		echo "random trigger connection test2: $contest"
+
+		if ( $con_test != "r" && $contest == 0 ) then
 			echo "JLAB Connection test failed. Falling back to UConn ...."
 			#echo "attempting to copy the needed file from an alternate source..."
 			setenv XRD_RANDOMS_URL root://nod25.phys.uconn.edu/Gluex/rawdata/

--- a/MakeMC.csh
+++ b/MakeMC.csh
@@ -207,7 +207,7 @@ if ( "$BATCHSYS" == "OSG" && "$BATCHRUN" == "1" ) then
 endif
 
 
-setenv XRD_RANDOMS_URL root://dtn2303.jlab.org/work/osgpool/halld/
+setenv XRD_RANDOMS_URL osdf://jlab-osdf/gluex/osgpool/random_triggers/
 setenv RANDOMS_PREPEND ""
 setenv LD_PRELOAD ""
 if ( "$MCWRAPPER_RUN_LOCATION" == "JLAB" || `hostname` =~ '*.jlab.org' ) then
@@ -222,7 +222,7 @@ if ( -f /usr/lib64/libXrdPosixPreload.so && "$BKGFOLDSTR" != "None" && "$GENR" !
 
 	if ( "$BKGFOLDSTR" == "Random" ) then
 		
-		set con_test=`ls $XRD_RANDOMS_URL/random_triggers/$RANDBGTAG/run$formatted_runNumber\_random.hddm | head -c 1`
+		set con_test=`/usr/bin/pelican object ls ${$XRD_RANDOMS_URL}/$RANDBGTAG/run$formatted_runNumber\_random.hddm | head -c 1`
 
 		if ( $con_test != "r" ) then
 			echo "JLAB Connection test failed. Falling back to UConn ...."

--- a/MakeMC.sh
+++ b/MakeMC.sh
@@ -260,7 +260,7 @@ elif [[ -f /usr/lib64/libXrdPosixPreload.so && "$BKGFOLDSTR" != "None" && "$GENR
 		echo "XRD_RANDOMS_URL: $XRD_RANDOMS_URL"
 		echo "RANDBGTAG: $RANDBGTAG"
 		echo "formatted_runNumber: $formatted_runNumber"
-export RANDOMS_OSDF=osdf://jlab-osdf/gluex/osgpool/random_triggers/
+
 		echo `ls $XRD_RANDOMS_URL/$RANDOMS_PREPEND/random_triggers/$RANDBGTAG/run$formatted_runNumber\_random.hddm`
 		export con_test=`ls $XRD_RANDOMS_URL/$RANDOMS_PREPEND/random_triggers/$RANDBGTAG/run$formatted_runNumber\_random.hddm | head -c 1`
 

--- a/MakeMC.sh
+++ b/MakeMC.sh
@@ -210,8 +210,8 @@ done
 formatted_runNumber=$formatted_runNumber$RUN_NUMBER
 flength_count=$((`echo $FILE_NUMBER | wc -c` - 1))
 
-export XRD_RANDOMS_URL=root://dtn2303.jlab.org
-export RANDOMS_PREPEND=/work/osgpool/halld/
+export XRD_RANDOMS_URL=root://dtn2304.jlab.org:8443
+export RANDOMS_PREPEND=/jlab-osdf-ro/halld/osgpool/
 if [[ "$BATCHSYS" == "OSG" && "$BATCHRUN"=="1" || `hostname` == 'scosg2201' ]]; then
 	export XRD_RANDOMS_URL=${RANDOMS_OSDF}
 	export RANDOMS_PREPEND=""
@@ -260,7 +260,7 @@ elif [[ -f /usr/lib64/libXrdPosixPreload.so && "$BKGFOLDSTR" != "None" && "$GENR
 		echo "XRD_RANDOMS_URL: $XRD_RANDOMS_URL"
 		echo "RANDBGTAG: $RANDBGTAG"
 		echo "formatted_runNumber: $formatted_runNumber"
-
+export RANDOMS_OSDF=osdf://jlab-osdf/gluex/osgpool/random_triggers/
 		echo `ls $XRD_RANDOMS_URL/$RANDOMS_PREPEND/random_triggers/$RANDBGTAG/run$formatted_runNumber\_random.hddm`
 		export con_test=`ls $XRD_RANDOMS_URL/$RANDOMS_PREPEND/random_triggers/$RANDBGTAG/run$formatted_runNumber\_random.hddm | head -c 1`
 


### PR DESCRIPTION
when dtn2303 was removed the randoms were inaccessible to anyone but the automated OSG.  Workarounds could include obtaining a token or citing a copy of the random trigger files.  Neither was acceptable.  Updated URL was given and inserted and the csh version was brought more inline.